### PR TITLE
docs: adds documentation around the org admin role

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -15,6 +15,16 @@ The project-wide oversight committee
 - [`mrgadgil`](https://github.com/mrgadgil)
 - [`yuji-watanabe-jp`](https://github.com/yuji-watanabe-jp)
 
+### Org Admins
+
+Team with admin access to the `oscal-compass` org.
+
+> Note: The purpose of this role is to restrict access to admin level functionality in the org. This team serves the community, but does not have decision-making power on their own. This team consists of the community maintainers and the Oversight Committee Chair.
+
+- [`jpower432`](https://github.com/jpower432)
+- [`vikas-agarwal76`](https://github.com/vikas-agarwal76)
+- TBD: Oversight Committee Chair
+
 ## Community
 
 ### Community Maintainers

--- a/MEMBERSHIP.md
+++ b/MEMBERSHIP.md
@@ -1,6 +1,6 @@
 # Community roles and membership
 
-This document outlines the various responsibilities of contributor roles in the OSCAL Compass organization. OSCAL Compass is made up of several projects that are defined as codebases and services with different release cycles, thus the responsibiltes for roles are scope to individual projects. Where applicable for OSCAL Compass overall, contributor status is equal to the highest status that they have on any project.
+This document outlines the various responsibilities of contributor roles in the OSCAL Compass organization. OSCAL Compass is made up of several projects that are defined as codebases and services with different release cycles, thus the responsibilities for roles are scope to individual projects. Where applicable for OSCAL Compass overall, contributor status is equal to the highest status that they have on any project.
 
 This document outlines a core number of contributor roles for OSCAL Compass projects, such as _Member_, _Triager_, and _Maintainer_. An _Oversight Committee_ also serves to supervise the overall OSCAL Compass project and its health. Using transparent criteria, the journey between roles is based on individual participation. Criteria will be reevaluated periodically to ensure that we can meet the needs of each project with the resources available to contribute.
 
@@ -123,4 +123,4 @@ Changes to contributor roles must be approved by a vote of the Oversight Committ
 
 ## Acknowledgements
 
-Contributor roles and responsibilities were adpated from InstructLab [contributor roles](https://raw.githubusercontent.com/instructlab/community/main/CONTRIBUTOR_ROLES.md)
+Contributor roles and responsibilities were adapted from InstructLab [contributor roles](https://raw.githubusercontent.com/instructlab/community/main/CONTRIBUTOR_ROLES.md)


### PR DESCRIPTION
Adds documentation around the org admin role in the community

Closes #33 