### PR TITLE
docs: updates `MAINTAINER.md` with corrections

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -12,6 +12,7 @@ The project-wide oversight committee
 - [`jpower432`](https://github.com/jpower432)
 - [`mrgadgil`](https://github.com/mrgadgil) - Chair
 - [`yuji-watanabe-jp`](https://github.com/yuji-watanabe-jp)
+- [`vikas-agarwal76`](https://github.com/vikas-agarwal76)
 
 ### Org Admins
 
@@ -23,6 +24,7 @@ Team with admin access to the `oscal-compass` org.
 - [`vikas-agarwal76`](https://github.com/vikas-agarwal76)
 - [`mrgadgil`](https://github.com/mrgadgil)
 - [`jflowers`](https://github.com/jflowers)
+- [`degenaro`](https://github.com/degenaro)
 - [`thelinuxfoundation`](https://github.com/thelinuxfoundation)
 
 ## Community
@@ -33,3 +35,4 @@ Team with maintainer access to the Community repository
 
 - [`jpower432`](https://github.com/jpower432)
 - [`vikas-agarwal76`](https://github.com/vikas-agarwal76)
+- [`degenaro`](https://github.com/degenaro)


### PR DESCRIPTION
This makes updates to the `MAINTAINERS.md` file to make corrections to current roles:

- Add @degenaro as a community maintainer and org admin
- Add @vikas-agarwal76 as a boostrap Oversight Committee member 