### PR TITLE
removes jay flowers from oversight committee and org maintainers to emeritus 

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,7 +8,6 @@ The project-wide oversight committee
 
 - [`ancatri`](https://github.com/ancatri)
 - [`degenaro`](https://github.com/degenaro)
-- [`jflowers`](https://github.com/jflowers) - Chair
 - [`jpower432`](https://github.com/jpower432)
 - [`mrgadgil`](https://github.com/mrgadgil) - Chair
 - [`yuji-watanabe-jp`](https://github.com/yuji-watanabe-jp)
@@ -23,7 +22,6 @@ Team with admin access to the `oscal-compass` org.
 - [`jpower432`](https://github.com/jpower432)
 - [`vikas-agarwal76`](https://github.com/vikas-agarwal76)
 - [`mrgadgil`](https://github.com/mrgadgil)
-- [`jflowers`](https://github.com/jflowers)
 - [`degenaro`](https://github.com/degenaro)
 - [`thelinuxfoundation`](https://github.com/thelinuxfoundation)
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -34,3 +34,10 @@ Team with maintainer access to the Community repository
 - [`jpower432`](https://github.com/jpower432)
 - [`vikas-agarwal76`](https://github.com/vikas-agarwal76)
 - [`degenaro`](https://github.com/degenaro)
+
+### Emeritus Maintainers
+
+Former Community Maintainers, thanks for your service!
+
+- [`jpower432`](https://github.com/jpower432)
+- [`jflowers`](https://github.com/jflowers)


### PR DESCRIPTION
This was not an easy decision, but I feel it is a necessary one at this time. I've decided to step back in order to refocus my time and energy on other professional priorities that require my full attention.

I believe it is in the best interest of the committee to be able to move forward with a fully unified perspective, and I feel I can no longer contribute effectively to the path being taken. It has been a privilege to serve on the committee, and I am grateful for the experience. I wish you and the rest of the committee the very best in all future endeavors.

I believe these are the steps to offboard me:
- Remove from community maintainers
- Transfer oscal-compass-oversight-committee slack channel and remove channel memberships
- Remove any direct permissions and role in associated GitHub teams
- Remove from CNCF [project-maintainers.csv](https://github.com/cncf/foundation/blob/1f92476c57d922301f5e110d0596e64ecc11e435/project-maintainers.csv#L1717)
